### PR TITLE
Rap1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- New `spaced_beads` parameters allow simulating arrays of obstacles on a DNA strand with
+tunable size, spacing, and angle stiffness.
+
 ### Changed
 
 - Simulations run with the --continue flag will now produce output.lammpstrj.1, output.lammpstrj.2, ... files

--- a/src/smc_lammps/generate/default_parameters.py
+++ b/src/smc_lammps/generate/default_parameters.py
@@ -89,6 +89,12 @@ class Parameters:
     spaced_beads_size: float = 5.0
     "radius of beads along DNA (nm)"
 
+    spaced_beads_full_dna: bool = False
+    "whether to place beads across the entire DNA length or not"
+
+    spaced_beads_smc_clearance: float = spaced_beads_size
+    "length of bare DNA to keep next to SMC"
+
     ##################### Geometry #####################
 
     arm_length = 50.0

--- a/src/smc_lammps/generate/default_parameters.py
+++ b/src/smc_lammps/generate/default_parameters.py
@@ -95,6 +95,9 @@ class Parameters:
     spaced_beads_smc_clearance: float = spaced_beads_size
     "length of bare DNA to keep next to SMC"
 
+    spaced_beads_custom_stiffness: float = 1.0
+    "multiple of the default DNA stiffness"
+
     ##################### Geometry #####################
 
     arm_length = 50.0

--- a/src/smc_lammps/generate/generate.py
+++ b/src/smc_lammps/generate/generate.py
@@ -604,13 +604,15 @@ with open(path / "post_processing_parameters.py", "w", encoding="utf-8") as file
         f"middle_right_bead_id = {gen.get_atom_index((smc_1.atp_grp, -1))}\n"
     )
     file.write("\n")
-    dna_indices_list = {
-        k: [(gen.get_atom_index(atomId1), gen.get_atom_index(atomId2)) for atomId1, atomId2 in lst]
-        for k, lst in ppp.dna_indices_list.items()
-    }
+
+    def do_map(lst):
+        return map(lambda tup: (gen.get_atom_index(tup[0]), gen.get_atom_index(tup[1])), lst)
+
+    dna_indices_list = {key: do_map(lst) for key, lst in ppp.dna_indices_list.items()}
     dna_indices_list = [
-        tup for lst in dna_indices_list.values() for tup in dna_config.strand_concat(lst)
+        dna_config.strand_concat(list(lst)) for lst in dna_indices_list.values()
     ]
+    dna_indices_list = [t for x in dna_indices_list for t in x]
     file.write(
         "# list of (min, max) of DNA indices for separate pieces to analyze\n"
         f"dna_indices_list = {dna_indices_list}\n"

--- a/src/smc_lammps/generate/generate.py
+++ b/src/smc_lammps/generate/generate.py
@@ -362,14 +362,17 @@ if par.spaced_beads_interval is not None:
     # get spacing
     start_id = par.spaced_beads_interval
     stop_id = get_closest(dna_config.dna_groups[0].positions, smc_positions.r_lower_site[1])
-    spaced_bead_ids = list(range(start_id, stop_id, par.spaced_beads_interval))
-    spaced_bead_ids += list(
-        range(
-            stop_id + par.spaced_beads_interval,
-            len(dna_config.dna_groups[0].positions),
-            par.spaced_beads_interval,
+    clearance = math.ceil(par.spaced_beads_smc_clearance / DNA_bond_length)
+    spaced_bead_ids = list(range(start_id, stop_id - clearance, par.spaced_beads_interval))
+
+    if par.spaced_beads_full_dna:
+        spaced_bead_ids += list(
+            range(
+                stop_id + clearance,
+                len(dna_config.dna_groups[0].positions),
+                par.spaced_beads_interval,
+            )
         )
-    )
 
     for dna_id in spaced_bead_ids:
         mol_spaced_bead = MoleculeId.get_next()

--- a/src/smc_lammps/generate/generate.py
+++ b/src/smc_lammps/generate/generate.py
@@ -347,7 +347,7 @@ if par.add_RNA_polymerase:
     else:
         raise ValueError(f"unknown RNA_polymerase_type, {par.RNA_polymerase_type}")
 
-    if hasattr(dna_config, "tether"):
+    if isinstance(dna_config.tether, dna.Tether):
         st_dna_id = dna_config.tether.dna_tether_id
     else:
         st_dna_id = (0, int(0.5 * dna_config.dna_strands[0].full_list_length()))
@@ -604,9 +604,12 @@ with open(path / "post_processing_parameters.py", "w", encoding="utf-8") as file
         f"middle_right_bead_id = {gen.get_atom_index((smc_1.atp_grp, -1))}\n"
     )
     file.write("\n")
+    dna_indices_list = {
+        k: [(gen.get_atom_index(atomId1), gen.get_atom_index(atomId2)) for atomId1, atomId2 in lst]
+        for k, lst in ppp.dna_indices_list.items()
+    }
     dna_indices_list = [
-        (gen.get_atom_index(atomId1), gen.get_atom_index(atomId2))
-        for (atomId1, atomId2) in ppp.dna_indices_list
+        tup for lst in dna_indices_list.values() for tup in dna_config.strand_concat(lst)
     ]
     file.write(
         "# list of (min, max) of DNA indices for separate pieces to analyze\n"
@@ -799,7 +802,7 @@ with open(path / "parameterfile", "w", encoding="utf-8") as parameterfile:
         parameterfile.write(get_universe_def("stretching_forces", sf_forces))
 
     # obstacle, if particle
-    if hasattr(dna_config, "tether") and isinstance(dna_config.tether.obstacle, dna.Tether.Gold):
+    if dna_config.tether is not None and isinstance(dna_config.tether.obstacle, dna.Tether.Gold):
         obstacle_lammps_id = gen.get_atom_index((dna_config.tether.obstacle.group, 0))
         parameterfile.write(f"variable obstacle_id equal {obstacle_lammps_id}\n")
 

--- a/src/smc_lammps/generate/generate.py
+++ b/src/smc_lammps/generate/generate.py
@@ -390,7 +390,7 @@ if par.spaced_beads_interval is not None:
             offset = int(par.spaced_beads_size / DNA_bond_length)
             try:
                 dna_config.change_dna_stiffness(
-                    0, st_dna_id - offset, st_dna_id + offset, dna_bond, stiff_dna_angle
+                    0, st_dna_id - offset, st_dna_id + offset + 1, dna_bond, stiff_dna_angle
                 )
             except ValueError as e:
                 print(e)

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -444,9 +444,9 @@ class DnaConfiguration:
             ip.rcut_lower_site_DNA,
         )
 
-        # every bead should repel every SMC group
+        # every bead should repel certain SMC groups
         for (bead, bead_size), smc_grp in product(
-            zip(self.beads, self.bead_sizes), self.smc.get_groups()
+            zip(self.beads, self.bead_sizes), self.smc.get_repulsive_groups()
         ):
             pair_inter.add_interaction(
                 bead.type,

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -706,8 +706,8 @@ class Folded(DnaConfiguration):
         return ppp
 
     def get_stopper_ids(self) -> List[StrandId]:
-        # TODO: maybe add bead at halfway point (left most point)?
-        return []
+        # add bead at halfway point
+        return [(0, self.dna_strands[0].convert_ratio(0.5))]
 
 
 class RightAngle(DnaConfiguration):

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -701,6 +701,7 @@ class Folded(DnaConfiguration):
         ]
 
         ppp.dna_indices_list[0] = self.dna_indices_list_get_dna_to(0, ratio=0.5)
+        ppp.dna_indices_list[1] = self.dna_indices_list_get_dna_from_to(0, from_ratio=0.5, to_ratio=1.0)
 
         return ppp
 

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -317,7 +317,7 @@ def with_tether(cls):
 
     def new4(f):
         def get_bonds(self) -> List[BAI]:
-            return f(self) + self.tether.get_bonds(self.dna_parameters.bond)
+            return f(self) + self.tether.get_bonds(self.dna_parameters.bond, self)
 
         return get_bonds
 

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -405,6 +405,11 @@ class DnaConfiguration:
     ) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
         return [tup for tup in self.dna_strands[strand_index].all_indices_list()]
 
+    def dna_indices_list_get_dna_from_to(
+        self, strand_index: int, from_ratio: float, to_ratio: float
+    ) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        return [tup for tup in self.dna_strands[strand_index].indices_list_from_to_percent(from_ratio, to_ratio)]
+
     def dna_indices_list_get_dna_to(
         self, strand_index: int, ratio: float
     ) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:

--- a/src/smc_lammps/generate/structures/dna/dna.py
+++ b/src/smc_lammps/generate/structures/dna/dna.py
@@ -384,13 +384,18 @@ class DnaConfiguration:
 
     @staticmethod
     def strand_concat(lst: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
-        new = []
-        for x, y in zip(lst, lst[1:]):
-            if x[1] + 1 == y[0]:
-                new.append((x[0], y[1]))
+        if not lst:
+            return lst
+
+        def fuse(alist: List[Tuple[int, int]], next: Tuple[int, int]):
+            if not alist or alist[-1][1] + 1 != next[0]:
+                alist.append(next)
             else:
-                new.append(x)
-                new.append(y)
+                alist[-1] = (alist[-1][0], next[1])
+
+        new = []
+        for item in lst:
+            fuse(new, item)
 
         return new
 
@@ -468,9 +473,7 @@ class DnaConfiguration:
             for bond in self.bead_bonds
         ]
 
-    def update_tether_bond(
-        self, old_id: AtomIdentifier, bead: None | AtomIdentifier
-    ) -> None:
+    def update_tether_bond(self, old_id: AtomIdentifier, bead: None | AtomIdentifier) -> None:
         assert isinstance(self.tether, Tether)
 
         if self.tether.dna_tether_id[0] is old_id[0]:

--- a/src/smc_lammps/generate/structures/polymer.py
+++ b/src/smc_lammps/generate/structures/polymer.py
@@ -18,9 +18,13 @@ class Polymer:
     def split(self, split: AtomIdentifier) -> Tuple[AtomGroup, AtomGroup]:
         """split the polymer in two pieces, with the split atom id part of the second group.
         Note: this simply changes the underlying atom groups"""
+        id = self.atom_groups.index(split[0])
         self.atom_groups.remove(split[0])
         pos1 = split[0].positions[: split[1]]
         pos2 = split[0].positions[split[1] :]
+
+        if len(pos1) == 0 or len(pos2) == 0:
+            raise ValueError("Empty group produced by split!")
 
         args = (
             split[0].type,
@@ -32,7 +36,9 @@ class Polymer:
             AtomGroup(pos1, *args),
             AtomGroup(pos2, *args),
         )
-        self.atom_groups += groups
+        for grp in groups[::-1]:
+            self.atom_groups.insert(id, grp)
+
         return groups
 
     def full_list(self) -> Nx3Array:

--- a/src/smc_lammps/generate/structures/polymer.py
+++ b/src/smc_lammps/generate/structures/polymer.py
@@ -1,0 +1,91 @@
+from typing import List, Tuple
+
+import numpy as np
+
+from smc_lammps.generate.generator import AtomGroup, AtomIdentifier, Nx3Array
+
+
+class Polymer:
+    """One connected polymer / strand, comprised of any number of atom groups"""
+
+    def __init__(self, *atom_groups: AtomGroup) -> None:
+        self.atom_groups: List[AtomGroup] = []
+        self.add(*atom_groups)
+
+    def add(self, *atom_groups: AtomGroup) -> None:
+        self.atom_groups += atom_groups
+
+    def split(self, split: AtomIdentifier) -> Tuple[AtomGroup, AtomGroup]:
+        """split the polymer in two pieces, with the split atom id part of the second group.
+        Note: this simply changes the underlying atom groups"""
+        self.atom_groups.remove(split[0])
+        pos1 = split[0].positions[: split[1]]
+        pos2 = split[0].positions[split[1] :]
+
+        args = (
+            split[0].type,
+            split[0].molecule_index,
+            split[0].polymer_bond_type,
+            split[0].polymer_angle_type,
+        )
+        groups = (
+            AtomGroup(pos1, *args),
+            AtomGroup(pos2, *args),
+        )
+        self.atom_groups += groups
+        return groups
+
+    def full_list(self) -> Nx3Array:
+        return np.concatenate([grp.positions for grp in self.atom_groups])
+
+    def full_list_length(self) -> int:
+        return len(self.full_list())
+
+    def get_id_from_list_index(self, index: int) -> AtomIdentifier:
+        if index < 0:
+            index += self.full_list_length()
+        assert index >= 0
+
+        for grp in self.atom_groups:
+            if index < len(grp.positions):
+                return (grp, index)
+            index -= len(grp.positions)
+
+        raise IndexError(f"index {index} out of bounds for atom groups.")
+
+    def all_indices_list(
+        self,
+    ) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        return [((dna_grp, 0), (dna_grp, -1)) for dna_grp in self.atom_groups]
+
+    def indices_list_to(self, index: int) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        if index < 0:
+            index += self.full_list_length()
+        assert index >= 0
+
+        lst = []
+        for grp in self.atom_groups:
+            lst.append(((grp, 0), (grp, -1)))
+            if index < len(grp.positions):
+                lst.pop()
+                lst.append(((grp, 0), (grp, index)))
+                return lst
+            index -= len(grp.positions)
+
+        raise IndexError(f"index {index} out of bounds for atom groups.")
+
+    def indices_list_to_percent(self, ratio: float) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        index = int(ratio * self.full_list_length())
+        if index < 0 or index >= self.full_list_length():
+            raise IndexError(f"ratio {ratio} out of bounds for atom groups.")
+
+        return self.indices_list_to(index)
+
+    def first_id(self) -> AtomIdentifier:
+        return self.get_id_from_list_index(0)
+
+    def last_id(self) -> AtomIdentifier:
+        return self.get_id_from_list_index(-1)
+
+    def get_percent_id(self, ratio: float) -> AtomIdentifier:
+        return self.get_id_from_list_index(int(ratio * self.full_list_length()))

--- a/src/smc_lammps/generate/structures/polymer.py
+++ b/src/smc_lammps/generate/structures/polymer.py
@@ -47,10 +47,16 @@ class Polymer:
     def full_list_length(self) -> int:
         return len(self.full_list())
 
-    def get_id_from_list_index(self, index: int) -> AtomIdentifier:
+    def handle_negative_index(self, index: int) -> int:
+        if index >= 0:
+            return index
+        index += self.full_list_length()
         if index < 0:
-            index += self.full_list_length()
-        assert index >= 0
+            raise IndexError("Index out of range.")
+        return index
+
+    def get_id_from_list_index(self, index: int) -> AtomIdentifier:
+        index = self.handle_negative_index(index)
 
         for grp in self.atom_groups:
             if index < len(grp.positions):
@@ -64,10 +70,40 @@ class Polymer:
     ) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
         return [((dna_grp, 0), (dna_grp, -1)) for dna_grp in self.atom_groups]
 
+    def indices_list_from_to(self, from_index: int, to_index: int) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        from_index = self.handle_negative_index(from_index)
+        to_index = self.handle_negative_index(to_index)
+
+        if from_index > to_index:
+            return []
+
+        lst = []
+        # go to from_index
+        i = 0
+        for i in range(len(self.atom_groups)):
+            grp = self.atom_groups[i]
+            if from_index < len(grp.positions):
+                if to_index < len(grp.positions):
+                    lst.append(((grp, from_index), (grp, to_index)))
+                    return lst
+                lst.append(((grp, from_index), (grp, -1)))
+                break
+            from_index -= len(grp.positions)
+            to_index -= len(grp.positions)
+
+        for j in range(i + 1, len(self.atom_groups)):
+            grp = self.atom_groups[j]
+            lst.append(((grp, 0), (grp, -1)))
+            if to_index < len(grp.positions):
+                lst.pop()
+                lst.append(((grp, 0), (grp, to_index)))
+                return lst
+            to_index -= len(grp.positions)
+
+        raise IndexError(f"index range ({from_index}, {to_index}) out of bounds for atom groups.")
+
     def indices_list_to(self, index: int) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
-        if index < 0:
-            index += self.full_list_length()
-        assert index >= 0
+        index = self.handle_negative_index(index)
 
         lst = []
         for grp in self.atom_groups:
@@ -80,10 +116,25 @@ class Polymer:
 
         raise IndexError(f"index {index} out of bounds for atom groups.")
 
-    def indices_list_to_percent(self, ratio: float) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+    def convert_ratio(self, ratio: float) -> int:
+        if ratio < 0.0 or ratio > 1.0:
+            raise IndexError(f"index ratio {ratio} is invalid.")
+
         index = int(ratio * self.full_list_length())
-        if index < 0 or index >= self.full_list_length():
-            raise IndexError(f"ratio {ratio} out of bounds for atom groups.")
+        if index == self.full_list_length():
+            # case where ratio is (almost) equal to 1
+            index -= 1
+
+        return index
+
+    def indices_list_from_to_percent(self, from_ratio: float, to_ratio: float) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        from_index = self.convert_ratio(from_ratio)
+        to_index = self.convert_ratio(to_ratio)
+
+        return self.indices_list_from_to(from_index, to_index)
+
+    def indices_list_to_percent(self, ratio: float) -> List[Tuple[AtomIdentifier, AtomIdentifier]]:
+        index = self.convert_ratio(ratio)
 
         return self.indices_list_to(index)
 

--- a/src/smc_lammps/generate/structures/smc/smc.py
+++ b/src/smc_lammps/generate/structures/smc/smc.py
@@ -253,6 +253,21 @@ class SMC:
         ]
         return [grp for grp in grps if grp.positions.size != 0]
 
+    def get_repulsive_groups(self) -> List[AtomGroup]:
+        """Returns a list of groups that should have a repulsive LJ interaction
+        with other (inert) beads such as obstacles."""
+        grps = [
+            self.arm_dl_grp,
+            self.arm_ul_grp,
+            self.arm_ur_grp,
+            self.arm_dr_grp,
+            self.hk_grp,
+            self.atp_grp,
+            self.hinge_l_grp,
+            self.hinge_r_grp,
+        ]
+        return [grp for grp in grps if grp.positions.size != 0]
+
     def get_bonds(self, hinge_opening: float | None = None) -> List[BAI]:
         # Every joint is kept in place through bonds
         attach = BAI_Type(

--- a/src/smc_lammps/generate/structures/structure_creator.py
+++ b/src/smc_lammps/generate/structures/structure_creator.py
@@ -5,7 +5,7 @@ from typing import List
 import numpy as np
 import numpy.typing as npt
 from scipy import interpolate
-from scipy.stats import trapezoid
+from scipy.integrate import trapezoid
 from scipy.spatial.transform import Rotation
 
 from smc_lammps.generate.generator import Nx3Array


### PR DESCRIPTION
Addition and changes to the `spaced_beads` parameters.

Changes to dna.py
 - separate strands are now stored as Polymer types, which represent a single strand that may contain various bond/angle types in different atom groups.
 - dna strands can now be split, and beads can be added at different points.

Changes to smc.py
 - binding site structures no longer repel beads (obstacles) on the dna